### PR TITLE
fix: Add permitHeaders to the `OPTIONS` request

### DIFF
--- a/src/server/core/proxy.ts
+++ b/src/server/core/proxy.ts
@@ -30,9 +30,14 @@ export function withBody(callback: (req: Request, res: Response) => void) {
 
 export function corsHandler(req: Request, res: Response) {
   const origin = req.headers.origin;
+  const headers = ['authorization', 'content-type'];
+  const requestHeaders = req.headers['access-control-request-headers'];
+  if (requestHeaders) {
+    headers.push(requestHeaders);
+  }
   res.statusCode = 200;
   res.setHeader('Access-Control-Allow-Origin', origin);
-  res.setHeader('Access-Control-Allow-Headers', 'authorization,content-type');
+  res.setHeader('Access-Control-Allow-Headers', headers.join(','));
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   return res.end();


### PR DESCRIPTION
To fix:
![image](https://user-images.githubusercontent.com/5674761/89147285-c70ce100-d588-11ea-8f73-1c51fdfbe00d.png)
![image](https://user-images.githubusercontent.com/5674761/89147325-e0159200-d588-11ea-8a83-db406b5a5327.png)
1. use cutome headers
2. use custom host