### PR TITLE
allow post with query string

### DIFF
--- a/src/server/helpers/compare-requests.ts
+++ b/src/server/helpers/compare-requests.ts
@@ -43,7 +43,9 @@ function serializedUrl(a: BasicKrasRequest) {
       return keys;
     }, [])
     .join('&');
-  return a.method.toLowerCase() === 'get' && queryString ? `${a.url}?${queryString}` : a.url;
+  return (a.method.toLowerCase() === 'get' || a.method.toLowerCase() === 'post') && queryString
+    ? `${a.url}?${queryString}`
+    : a.url;
 }
 
 export function compareRequests(a: BasicKrasRequest, b: BasicKrasRequest) {


### PR DESCRIPTION
Sending a POST with a query string but without a body seems odd, but it can be appropriate in some situations.