### PR TITLE
refactor: read cert from node_modules

### DIFF
--- a/src/server/core/config.ts
+++ b/src/server/core/config.ts
@@ -215,8 +215,8 @@ export const defaultConfig = {
   directory: resolve(currentDir, 'mocks'),
   client: 'kras-management-portal',
   ssl: {
-    cert: resolve(rootDir, 'cert', 'server.crt'),
-    key: resolve(rootDir, 'cert', 'server.key'),
+    cert: 'kras/cert/server.crt',
+    key: 'kras/cert/server.key',
   },
   uploadLimit: parseInt(process.env.FILE_SIZE_LIMIT, 10) || 10, // default: 10 MB
   logLevel: 'error',

--- a/src/server/core/readSsl.ts
+++ b/src/server/core/readSsl.ts
@@ -3,11 +3,10 @@ import { SslConfiguration } from '../types';
 
 function fileReader(path: string) {
   try {
-    return readFileSync(path);
-  } catch (e) {
-    // try to read file from node_modules
-    return readFileSync(require.resolve(path));
-  }
+    path = require.resolve(path);
+  } catch {}
+
+  return readFileSync(path);
 }
 
 export function readSsl(config?: Partial<SslConfiguration>) {

--- a/src/server/core/readSsl.ts
+++ b/src/server/core/readSsl.ts
@@ -1,11 +1,20 @@
 import { readFileSync } from 'fs';
 import { SslConfiguration } from '../types';
 
+function fileReader(path: string) {
+  try {
+    return readFileSync(path);
+  } catch (e) {
+    // try to read file from node_modules
+    return readFileSync(require.resolve(path));
+  }
+}
+
 export function readSsl(config?: Partial<SslConfiguration>) {
   if (typeof config === 'object' && config.key && config.cert) {
     return {
-      key: readFileSync(config.key),
-      cert: readFileSync(config.cert),
+      key: fileReader(config.key),
+      cert: fileReader(config.cert),
     };
   }
 }


### PR DESCRIPTION
If I'm using Yarn Workspaces (or Lerna), the following relative paths may be required:

```json
{
  "ssl": {
    "cert": "../../node_modules/kras/cert/server.crt",
    "key": "../../node_modules/kras/cert/server.key"
  }
}
```

When supporting reading certificate files from node_modules:
```json
{
  "ssl": {
    "cert": "kras/cert/server.crt",
    "key": "kras/cert/server.key"
  }
}
```
