### PR TITLE
fix: Fix Issue #63 to properly set the x-forwarded-host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.4 (tbd)
+
+- Fixed the `x-forwarded-host` header value
+
 ## 0.15.3
 
 - Added possibility to specify multiple headers or query parameters

--- a/docs/proxy-injector.md
+++ b/docs/proxy-injector.md
@@ -20,16 +20,18 @@ interface ProxyInjectorConfiguration {
   active?: boolean;
   agentOptions?: any;
   proxy?: any;
+  xfwd?: boolean;
   defaultHeaders?: Array<string>;
   discardHeaders?: Array<string>;
   permitHeaders?: Array<string>;
+  injectHeaders?: Record<string, string>;
   followRedirect?: boolean;
 }
 ```
 
 The mapping is already a general configuration, as the targets need to be known as well as their usual counterparts (e.g., to identify the correct URLs in an HAR file). The `agentOptions` can be used to specify more sophisticated options for the proxyed request (e.g., which ciphers to use). The `proxy` option allows us to set a (corporate?) proxy to be used on the local machine (oh the irony - a proxy server that allows setting another proxy ...).
 
-While the `defaultHeaders` provide a way to override the used default set of headers, `permitHeaders` are for explicitly allowing non-default headers and `discardHeaders` may be used to define which headers should never be considered.
+While the `defaultHeaders` provide a way to override the used default set of headers, `permitHeaders` are for explicitly allowing non-default headers and `discardHeaders` may be used to define which headers should never be considered, and `injectHeaders` may be used to create or override headers with custom values.
 
 If not explicitly specified the default headers are defined to be:
 
@@ -50,3 +52,11 @@ const defaultProxyHeaders = [
   'range',
 ];
 ```
+
+The `xfwd` option will create the following headers:|
+- x-forwarded-for
+- x-forwarded-host
+- x-forwarded-port
+- x-forwarded-proto
+
+and set the header values as derived from the original request. The `x-forwarded-host` header will contain the request's `host` header value, which may include a port number.

--- a/docs/proxy-injector.md
+++ b/docs/proxy-injector.md
@@ -53,7 +53,7 @@ const defaultProxyHeaders = [
 ];
 ```
 
-The `xfwd` option will create the following headers:|
+The `xfwd` option will create the following headers:
 - x-forwarded-for
 - x-forwarded-host
 - x-forwarded-port

--- a/src/server/injectors/proxy-injector.ts
+++ b/src/server/injectors/proxy-injector.ts
@@ -208,7 +208,7 @@ export default class ProxyInjector implements KrasInjector {
 
     if (this.config.xfwd) {
       integrateXfwd(headers, protocol, req);
-      headers['x-forwarded-host'] = headers['x-forwarded-host'] || headers.host || '';
+      headers['x-forwarded-host'] = headers['x-forwarded-host'] || req.headers.host || '';
     }
 
     return headers;


### PR DESCRIPTION
Fix for #63 

When the `xfwd` configuration option is enabled, the `x-forwarded-host` header was getting set with an empty value.  This fixes the issue by reading the `host` header from the original request.